### PR TITLE
Fixed issue where the package is missing request and thus prevents the user from running the node server.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "~4.13.1",
     "jade": "~1.11.0",
     "morgan": "~1.6.1",
+    "request": "^2.76.0",
     "serve-favicon": "~2.3.0"
   }
 }


### PR DESCRIPTION
Hi Perry,
I had an issue running the Node server because it was missing requests. By installing request:

`npm install request —save`

I was able to fix this issue. I hope updating this in package.json will help others that might run into this issue. 